### PR TITLE
Filesystem-based component rendering

### DIFF
--- a/app/helpers/fortitude_rails/application_helper.rb
+++ b/app/helpers/fortitude_rails/application_helper.rb
@@ -16,11 +16,38 @@ module FortitudeRails
       'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
     end
 
-    def render_fortitude_component(name)
-      render "fortitude_rails/components/#{name}"
-    rescue ActionView::MissingTemplate => e
-      Rails.logger.error e
-      "<h2>#{name} documentation not found.</h2>".html_safe
+    def render_nav_tree(components, path = '')
+      html = ''
+      components.each do |name, val|
+        name = name.to_s
+        component = name[0] == '_' ? name[1..-1] : name
+        component = component.split('.').first
+        html << "<li><a href='##{component}' class='list-navigation__link'>#{component.titleize}</a>"
+        if val.is_a?(Hash)
+          html << '<ul class="bare-list bare-list--dotted-line">'
+          html << render_nav_tree(val, File.join(path, name))
+          html << '</ul>'
+        end
+      end
+      html << "</li>"
+      html.html_safe
+    end
+
+    def render_component_tree(components, path = '')
+      html = ''
+      components.each do |name, val|
+        name = name.to_s
+        if(val.is_a?(Hash))
+          html << render_component_tree(val, File.join(path, name))
+        else
+          component = name[0] == '_' ? name[1..-1] : name
+          component = component.split('.').first
+          html << "<div class='layout xs-mtb2 xs-mr2' id='#{component}'>"
+          html << render(partial: File.join('fortitude_rails', path, component))
+          html << '</div>'
+        end
+      end
+      html.html_safe
     end
 
     def escaped(template)

--- a/app/views/fortitude_rails/static/docs.html.haml
+++ b/app/views/fortitude_rails/static/docs.html.haml
@@ -4,11 +4,7 @@
       .sidebar__inner{style: 'top: 9rem'}
         %h2.text-black-light.xs-beta.xs-inset2.xs-mb1 Components
         %ul.list-navigation
-          - theme_components.each do |component_name|
-            %li
-              %a.list-navigation__link{href: "##{component_name.pluralize}"} #{component_name.humanize.pluralize}
+          = render_nav_tree(theme_components)
 
   .layout__item.sm-8of12.md-9of12><
-    - theme_components.each do |component_name|
-      .layout.xs-mb2.xs-mr2{id: component_name.pluralize}
-        = render_fortitude_component(component_name)
+    = render_component_tree(theme_components)

--- a/lib/fortitude_rails/configuration.rb
+++ b/lib/fortitude_rails/configuration.rb
@@ -3,9 +3,10 @@ module FortitudeRails
     GEM_PATH = File.expand_path '../..', File.dirname(__FILE__)
 
     OPTIONS = [
-      :theme_intents,
       :theme_components,
+      :theme_intents,
       :theme_namespace,
+      :app_root,
       :stylesheet
     ]
 
@@ -24,35 +25,7 @@ module FortitudeRails
     end
 
     def set_default_configuration
-      self.theme_components = %w(
-        badge
-        bare_list
-        block_list
-        box
-        button
-        container
-        element
-        flag
-        flashbar
-        fluid_container
-        form
-        inline_list
-        layout
-        list_navigation
-        media
-        modal
-        navigationbar
-        shade
-        table
-        tabs
-        tabs_navigation
-        tooltip
-        typography
-        ui_list
-        wings
-        utilities
-      )
-
+      self.theme_components = doc_pages
       self.theme_intents = %w(
         default
         primary
@@ -67,10 +40,45 @@ module FortitudeRails
       self
     end
 
+    def gem_path
+      GEM_PATH
+    end
+
+    def doc_pages
+      @doc_pages ||= { 
+        'components' => directory_hash(File.join(gem_path, 'app', 'views', 'fortitude_rails', 'components'))
+      }
+    end
+
+    def app_pages
+      return @app_pages if @app_pages
+      return {} unless app_root
+      if Dir.exists?(File.join(app_root, 'app', 'views', 'fortitude_rails', 'components'))
+        @app_pages = { 'components' => directory_hash(Rails.root.join('app', 'views', 'fortitude_rails', 'components')) }
+      else
+        @app_pages = {}
+      end
+    end
+
     OPTIONS.each do |option|
       define_method "#{option}?" do
         self.send(option).present?
       end
     end
+
+    private
+      def directory_hash(path, name=nil)
+        data = {}
+        Dir.foreach(path) do |entry|
+          next if (entry == '..' || entry == '.')
+          full_path = File.join(path, entry)
+          if File.directory?(full_path)
+            data[entry] = directory_hash(full_path, entry)
+          else
+            data[entry] = 'file'
+          end
+        end
+        return data
+      end
   end
 end

--- a/lib/fortitude_rails/engine.rb
+++ b/lib/fortitude_rails/engine.rb
@@ -1,5 +1,9 @@
 module FortitudeRails
   class Engine < ::Rails::Engine
     isolate_namespace FortitudeRails
+    initializer "my_engine.load_app_root" do |app|
+      FortitudeRails.app_root = app.root
+      FortitudeRails.theme_components = FortitudeRails.theme_components.deep_merge(FortitudeRails.app_pages)
+    end
   end
 end

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -11,4 +11,14 @@ describe FortitudeRails::StaticController do
     end
   end
 
+  context '#docs' do
+
+    it 'renders pages from gem, app, and nested' do
+      get :docs
+      expect(response).to render_template(partial: 'fortitude_rails/components/_box')
+      expect(response).to render_template(partial: 'fortitude_rails/components/_app_specific')
+      expect(response).to render_template(partial: 'fortitude_rails/components/nested/_nested_component')
+    end
+  end
+
 end

--- a/spec/dummy/app/views/fortitude_rails/components/_app_specific.html.erb
+++ b/spec/dummy/app/views/fortitude_rails/components/_app_specific.html.erb
@@ -1,0 +1,1 @@
+<h1>App Specific</h1>

--- a/spec/dummy/app/views/fortitude_rails/components/nested/_nested_component.html.erb
+++ b/spec/dummy/app/views/fortitude_rails/components/nested/_nested_component.html.erb
@@ -1,0 +1,1 @@
+%h1 no docs

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe FortitudeRails::ApplicationHelper do
+
+  it 'returns theme intents' do
+    expect(helper.theme_intents).to eq(FortitudeRails.theme_intents)
+  end
+
+  it 'returns theme components' do
+    expect(helper.theme_components).to eq(FortitudeRails.theme_components)
+  end
+
+  it 'renders escaped html' do
+    expect(helper.escaped('fortitude_rails/components/app_specific')).to eq('&lt;h1&gt;App Specific&lt;/h1&gt;')
+  end
+
+  it 'renders nav tree' do
+    components = {components: {'_box.html.haml' => 'file'}}
+    rendered = <<-HTML
+    <li><a href='#components' class='list-navigation__link'>Components</a><ul class="bare-list bare-list--dotted-line"><li><a href='#box' class='list-navigation__link'>Box</a></li></ul></li>
+    HTML
+    expect(helper.render_nav_tree(components)).to eq(rendered.strip)
+  end
+
+  it 'renders component tree' do
+    components = {components: {'_box.html.haml' => 'file'}}
+    rendered = <<-HTML
+    <div class='layout xs-mtb2 xs-mr2' id='box'>#{render partial: 'fortitude_rails/components/box'}</div>
+    HTML
+    expect(helper.render_component_tree(components)).to eq(rendered.strip)
+  end
+
+end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -4,7 +4,17 @@ describe FortitudeRails::Configuration do
 
   subject { Class.new { extend FortitudeRails::Configuration } }
 
-  before { subject.set_default_configuration }
+  before do
+    subject.set_default_configuration
+    subject.app_root = File.join(File.dirname(File.expand_path(__FILE__)), '..', 'dummy')
+    subject.theme_components = subject.theme_components.deep_merge(subject.app_pages)
+  end
+
+  it 'sets theme components' do
+    expect(subject.theme_components['components'].keys).to include('_flag.html.haml')        # from the engine
+    expect(subject.theme_components['components'].keys).to include('_app_specific.html.erb') # from the dummy app
+    expect(subject.theme_components['components']['nested'].keys).to include('_nested_component.html.erb') # from the dummy app
+  end
 
   it 'allows setting theme intents' do
     expect{subject.theme_intents = ['intent']}.to change{subject.theme_intents}

--- a/spec/lib/fortitude_rails_spec.rb
+++ b/spec/lib/fortitude_rails_spec.rb
@@ -8,7 +8,7 @@ describe FortitudeRails do
   end
 
   it 'has theme components' do
-    expect(subject.theme_components).to be_an(Array)
+    expect(subject.theme_components).to be_a(Hash)
   end
 
 end


### PR DESCRIPTION
Devs no longer need to specify `theme_components` - they will be pulled from the filesystem. Also, you can include components you've written by putting a template in 

`yourapp/views/fortitude_rails/components/any/nested/directory/_app_component.html.jade`

Thinking it's worth separating out sub-folders into their own pages, but that can be next PR.